### PR TITLE
feat: separate worker into ingestion and export instances(MAPCO-9571)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,4 +1,5 @@
 {
+  "instanceType": "INSTANCE_TYPE",
   "telemetry": {
     "serviceName": "TELEMETRY_SERVICE_NAME",
     "hostname": "TELEMETRY_HOST_NAME",

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,5 @@
 {
-  "instanceType": "ingestion",
+  "instanceType": "",
   "telemetry": {
     "logger": {
       "level": "info",

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
+  "instanceType": "ingestion",
   "telemetry": {
     "logger": {
       "level": "info",

--- a/config/test.json
+++ b/config/test.json
@@ -1,4 +1,5 @@
 {
+  "instanceType": "ingestion",
   "telemetry": {
     "logger": {
       "level": "info",

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -60,6 +60,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Validates that instanceType is set to a supported value. Fails the render otherwise.
+*/}}
+{{- define "polygon-parts-worker.validateInstanceType" -}}
+{{- if not (has .Values.instanceType (list "ingestion" "export")) -}}
+{{- fail (printf "instanceType must be set to one of: ingestion, export (got: %q)" .Values.instanceType) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns the environment from global if exists or from the chart's values, defaults to development
 */}}
 {{- define "polygon-parts-worker.environment" -}}

--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -69,6 +69,10 @@ Custom definitions
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.tracing .Values.global.tracing ) "context" . ) }}
 {{- end -}}
 
+{{- define "common.metrics.merged" -}}
+{{- include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics .Values.global.metrics ) "context" . ) }}
+{{- end -}}
+
 {{- define "common.openTelemetryOptions.merged" -}}
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.env.openTelemetryOptions .Values.global.openTelemetryOptions ) "context" . ) }}
 {{- end -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -7,6 +7,7 @@
 {{ $gpkgLocation := clean (printf "/%s/%s" $fs.internalPvc.mountPath $fs.internalPvc.gpkgSubPath) }}
 {{ $validationReportsLocation := clean (printf "/%s/%s" $fs.internalPvc.mountPath $fs.internalPvc.reportsPath) }}
 {{- $storage := (include "common.storage.merged" .) | fromYaml }}
+{{- include "polygon-parts-worker.validateInstanceType" . }}
 
 
 {{- if .Values.enabled -}}
@@ -15,6 +16,7 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-configmap" (include "polygon-parts-worker.fullname" .) }}
 data:
+  INSTANCE_TYPE: {{ .Values.instanceType | quote }}
   REQUEST_PAYLOAD_LIMIT: {{ .Values.env.requestPayloadLimit | quote }}
   RESPONSE_COMPRESSION_ENABLED: {{ .Values.env.responseCompressionEnabled | quote }}
   LOG_LEVEL: {{ .Values.env.logLevel | quote }}
@@ -39,33 +41,37 @@ data:
   JOB_TRACKER_BASE_URL: {{ $serviceUrls.jobTracker | quote}}
   HEARTBEAT_INTERVAL_MS: {{ .Values.env.jobManagement.config.heartBeat.intervalMs | quote }}
   DEQUEUE_INTERVAL_MS: {{ .Values.env.jobManagement.config.dequeueIntervalMs | quote }}
+  POLYGON_PARTS_TASK_MAX_ATTEMPTS: {{ $jobDefinitions.tasks.polygonParts.maxAttempts | quote }}
+  npm_config_cache: /tmp/
+  HTTP_RETRY_ATTEMPTS: {{ .Values.env.httpRetry.attempts | quote }}
+  HTTP_RETRY_DELAY: {{ .Values.env.httpRetry.delay | quote }}
+  HTTP_RETRY_RESET_TIMEOUT: {{ .Values.env.httpRetry.resetTimeout | quote }}
+  DISABLE_HTTP_CLIENT_LOGS: {{ .Values.env.disableHttpClientLogs | quote }}
+  {{- if eq .Values.instanceType "ingestion" }}
+  INGESTION_NEW_JOB_TYPE: {{ $jobDefinitions.jobs.new.type }}
+  INGESTION_UPDATE_JOB_TYPE: {{ $jobDefinitions.jobs.update.type }}
+  INGESTION_SWAP_UPDATE_JOB_TYPE: {{ $jobDefinitions.jobs.swapUpdate.type }}
   VALIDATION_TASK_TYPE: {{ $jobDefinitions.tasks.validation.type }}
   VALIDATION_TASK_MAX_ATTEMPTS: {{ $jobDefinitions.tasks.validation.maxAttempts | quote }}
   VALIDATION_TASK_CHUNK_MAX_VERTICES: {{ $jobDefinitions.tasks.validation.chunkMaxVertices | quote }}
   VALIDATION_TASK_SMALL_GEOMETRIES_PERCENTAGE_THRESHOLD: {{ $jobDefinitions.tasks.validation.smallGeometriesPercentageThreshold | quote }}
   VALIDATION_TASK_SMALL_HOLES_PERCENTAGE_THRESHOLD: {{ $jobDefinitions.tasks.validation.smallHolesPercentageThreshold | quote }}
   VALIDATION_REPORTS_PATH: {{ $validationReportsLocation | quote }}
-  INGESTION_NEW_JOB_TYPE: {{ $jobDefinitions.jobs.new.type }}
-  INGESTION_UPDATE_JOB_TYPE: {{ $jobDefinitions.jobs.update.type }}
-  INGESTION_SWAP_UPDATE_JOB_TYPE: {{ $jobDefinitions.jobs.swapUpdate.type }}
-  EXPORT_JOB_TYPE: {{ $jobDefinitions.jobs.export.type }}
-  POLYGON_PARTS_TASK_MAX_ATTEMPTS: {{ $jobDefinitions.tasks.polygonParts.maxAttempts | quote }}
-  GPKGS_LOCATION: {{ $gpkgLocation | quote }}
-  npm_config_cache: /tmp/
-  HTTP_RETRY_ATTEMPTS: {{ .Values.env.httpRetry.attempts | quote }}
-  HTTP_RETRY_DELAY: {{ .Values.env.httpRetry.delay | quote }}
-  HTTP_RETRY_RESET_TIMEOUT: {{ .Values.env.httpRetry.resetTimeout | quote }}
-  DISABLE_HTTP_CLIENT_LOGS: {{ .Values.env.disableHttpClientLogs | quote }}
   INGESTION_SOURCES_DIR_PATH: {{ printf "/%s" $fs.ingestionSourcePvc.mountPath | quote }}
+  REPORT_STORAGE_PROVIDER: {{ $storage.reportProvider }}
+  DOWNLOAD_SERVER_PUBLIC_DNS: {{ $serviceUrls.downloadServerPublicDNS | quote }}
+  DOWNLOAD_SERVER_REPORTS_DOWNLOAD_PATH: {{ $jobDefinitions.tasks.validation.reportsDownloadPath | quote }}
   {{ if eq (upper $storage.reportProvider) "S3" }}
   {{- $s3HttpProtocol := ternary "https://" "http://" $storage.s3.sslEnabled -}}
   S3_ENDPOINT_URL: {{ printf "%s%s" $s3HttpProtocol $storage.s3.endpointUrl | quote }}
   S3_ARTIFACTS_BUCKET: {{ $storage.s3.artifactsBucket | quote }}
   S3_SSL_ENABLED: {{ $storage.s3.sslEnabled | quote }}
   {{- end }}
-  REPORT_STORAGE_PROVIDER: {{ $storage.reportProvider }}
-  DOWNLOAD_SERVER_PUBLIC_DNS: {{ $serviceUrls.downloadServerPublicDNS | quote }}
-  DOWNLOAD_SERVER_REPORTS_DOWNLOAD_PATH: {{ $jobDefinitions.tasks.validation.reportsDownloadPath | quote }}
+  {{- end }}
+  {{- if eq .Values.instanceType "export" }}
+  EXPORT_JOB_TYPE: {{ $jobDefinitions.jobs.export.type }}
+  GPKGS_LOCATION: {{ $gpkgLocation | quote }}
+  {{- end }}
   {{- with .Values.configManagement }}
   CONFIG_NAME: {{ .name | quote }}
   CONFIG_VERSION: {{ .version | quote }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "polygon-parts-worker.validateInstanceType" . -}}
 {{- $releaseName := .Release.Name -}}
 {{- $chartName := include "polygon-parts-worker.name" . -}}
 {{- $metrics := (include "common.metrics.merged" .) | fromYaml }}
@@ -76,9 +77,9 @@ spec:
             - name: {{ $internalVolumeName }}
               mountPath: {{ $fs.internalPvc.mountPath }}
             {{- end }}  
-            {{- if $fs.ingestionSourcePvc.enabled }}
+            {{- if and (eq .Values.instanceType "ingestion") $fs.ingestionSourcePvc.enabled }}
             - name: ingestion-storage
-              mountPath: {{ $fs.ingestionSourcePvc.mountPath }} 
+              mountPath: {{ $fs.ingestionSourcePvc.mountPath }}
               subPath: {{ $fs.ingestionSourcePvc.subPath }}
             {{- end }}
             {{- if .Values.extraVolumeMounts -}}
@@ -100,7 +101,7 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
-            {{- if eq (upper $storage.reportProvider) "S3" }}
+            {{- if and (eq .Values.instanceType "ingestion") (eq (upper $storage.reportProvider) "S3") }}
             - name: S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -111,7 +112,7 @@ spec:
                 secretKeyRef:
                   name: {{ $storage.s3.secretName }}
                   key: secretAccessKey
-            {{- end }}               
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ printf "%s-configmap" (include "polygon-parts-worker.fullname" .) }}
@@ -153,7 +154,7 @@ spec:
           secret:
             secretName: {{ .Values.caSecretName }}
         {{- end }}
-        {{- if $fs.ingestionSourcePvc.enabled }}
+        {{- if and (eq .Values.instanceType "ingestion") $fs.ingestionSourcePvc.enabled }}
         - name: ingestion-storage
           persistentVolumeClaim:
             claimName: {{ $fs.ingestionSourcePvc.name }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,3 +1,7 @@
+# instanceType selects which jobs this deployment polls and which resources it carries.
+# Must be set to one of: ingestion | export
+instanceType: ""
+
 global:
   cloudProvider: {}
   tracing: {}
@@ -81,7 +85,7 @@ metrics:
     scrape: false
 
 configManagement:
-  offlineMode: false
+  offlineMode: true
   name: 'polygon-parts-worker'
   version: 'latest'
   serverUrl: 'http://localhost:8080/api'
@@ -168,7 +172,7 @@ resources:
       memory: 128Mi
 
 route:
-  enabled: true
+  enabled: false
   path: /
   host:
   timeout:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@map-colonies/mc-priority-queue": "^9.1.0",
         "@map-colonies/mc-utils": "^5.1.0",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "^8.0.0-alpha",
+        "@map-colonies/raster-shared": "^8.2.0",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/shapefile-reader": "^1.0.1",
@@ -3280,7 +3280,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.0.0-alpha.0",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.2.0.tgz",
+      "integrity": "sha512-ZdNixVp+7Kw2ZWkRAWFhc2HP43yq9t3ogbv9HzHmI1DU1FiheXnEsJ9UMsSgjwWHY+GqgEy0ElFVE5wf6APtQw==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",
@@ -10281,9 +10283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10302,9 +10301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10323,9 +10319,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10344,9 +10337,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10365,9 +10355,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10386,9 +10373,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12808,9 +12792,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12825,9 +12806,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12842,9 +12820,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12859,9 +12834,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12876,9 +12848,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12893,9 +12862,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12910,9 +12876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12927,9 +12890,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@map-colonies/mc-priority-queue": "^9.1.0",
     "@map-colonies/mc-utils": "^5.1.0",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "^8.0.0-alpha",
+    "@map-colonies/raster-shared": "^8.2.0",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/shapefile-reader": "^1.0.1",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,21 +1,5 @@
 import { readPackageJsonSync } from '@map-colonies/read-pkg';
-import { getConfig, type ConfigType } from './config';
-
-/* Job handler DI tokens: resolve from config after init — do not read config at module load time. */
-/* eslint-disable @typescript-eslint/naming-convention */
-interface JobDefinitionsJobs {
-  new: { type: string };
-  update: { type: string };
-  swapUpdate: { type: string };
-  export: { type: string };
-}
-
-interface HandlerTokens {
-  NEW: string;
-  UPDATE: string;
-  SWAP: string;
-  EXPORT: string;
-}
+/* eslint-disable @typescript-eslint/naming-convention -- DI tokens and enum-like constants use UPPER_CASE keys */
 
 export const SERVICE_NAME = readPackageJsonSync().name ?? 'unknown_service';
 export const DEFAULT_SERVER_PORT = 80;
@@ -34,6 +18,11 @@ export const SERVICES = {
   TASK_METRICS: Symbol('TaskMetrics'),
   SHAPE_FILE_METRICS: Symbol('ShapeFileMetrics'),
   TRACING: Symbol('TracingManager'),
+} satisfies Record<string, symbol>;
+
+export const HANDLER_TOKENS = {
+  INGESTION: Symbol('IngestionJobHandler'),
+  EXPORT: Symbol('ExportJobHandler'),
 } satisfies Record<string, symbol>;
 
 export const StorageProvider = {
@@ -56,17 +45,4 @@ export const ZIP_CONTENT_TYPE = 'application/zip';
 
 export const UTF8_ENCODING = 'utf-8';
 
-export function getHandlerTokens(config: ConfigType): HandlerTokens {
-  const jobs = config.get('jobDefinitions.jobs') as unknown as JobDefinitionsJobs;
-  return {
-    NEW: jobs.new.type,
-    UPDATE: jobs.update.type,
-    SWAP: jobs.swapUpdate.type,
-    EXPORT: jobs.export.type,
-  };
-}
-
-export function getHandlers(): HandlerTokens {
-  return getHandlerTokens(getConfig());
-}
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -40,10 +40,10 @@ export interface IJobHandler<TJobParams = unknown, TTaskParams = unknown> {
 }
 
 export interface IPermittedJobTypes {
-  ingestionNew: string;
-  ingestionUpdate: string;
-  ingestionSwapUpdate: string;
-  exportJob: string;
+  ingestionNew?: string;
+  ingestionUpdate?: string;
+  ingestionSwapUpdate?: string;
+  exportJob?: string;
 }
 
 export interface ITaskConfig {

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -7,8 +7,9 @@ import type { Logger } from '@map-colonies/js-logger';
 import { instancePerContainerCachingFactory } from 'tsyringe';
 import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import type { IHttpRetryConfig } from '@map-colonies/mc-utils';
+import { InstanceType } from '@map-colonies/raster-shared';
 import { Registry } from 'prom-client';
-import { getHandlerTokens, SERVICES, SERVICE_NAME } from './common/constants';
+import { HANDLER_TOKENS, SERVICES, SERVICE_NAME } from './common/constants';
 import { getTracing } from './common/tracing';
 import { InjectionObject, registerDependencies } from './common/dependencyRegistration';
 import type { IJobManagerConfig } from './common/interfaces';
@@ -32,14 +33,17 @@ const queueClientFactory = (container: DependencyContainer): QueueClient => {
   );
 };
 
-const validateRequiredDirectories = (container: DependencyContainer): void => {
+const validateRequiredDirectories = (container: DependencyContainer, instanceType: InstanceType): void => {
   const config = container.resolve<ConfigType>(SERVICES.CONFIG);
   const logger = container.resolve<Logger>(SERVICES.LOGGER);
 
-  const requiredDirectories = [
-    { name: 'reportsPath', path: config.get('reportsPath') as string },
-    { name: 'ingestionSourcesDirPath', path: config.get('ingestionSourcesDirPath') as string },
-  ];
+  const requiredDirectories =
+    instanceType === InstanceType.INGESTION
+      ? [
+          { name: 'reportsPath', path: config.get('reportsPath') as string },
+          { name: 'ingestionSourcesDirPath', path: config.get('ingestionSourcesDirPath') as string },
+        ]
+      : [{ name: 'gpkgsLocation', path: config.get('gpkgsLocation') as string }];
 
   const missingDirectories: string[] = [];
 
@@ -63,6 +67,22 @@ const validateRequiredDirectories = (container: DependencyContainer): void => {
   }
 };
 
+const getInstanceType = (config: ConfigType): InstanceType => {
+  const instanceType = config.get('instanceType') as string;
+  const allowed = Object.values(InstanceType) as string[];
+  if (!allowed.includes(instanceType)) {
+    throw new Error(`invalid instanceType '${instanceType}', must be one of: ${allowed.join(', ')}`);
+  }
+  return instanceType as InstanceType;
+};
+
+const getHandlerDependencies = (instanceType: InstanceType): InjectionObject<unknown>[] => {
+  if (instanceType === InstanceType.INGESTION) {
+    return [{ token: HANDLER_TOKENS.INGESTION, provider: { useClass: IngestionJobHandler } }];
+  }
+  return [{ token: HANDLER_TOKENS.EXPORT, provider: { useClass: ExportJobHandler } }];
+};
+
 export interface RegisterOptions {
   override?: InjectionObject<unknown>[];
   useChild?: boolean;
@@ -70,7 +90,7 @@ export interface RegisterOptions {
 
 export const registerExternalValues = async (options?: RegisterOptions): Promise<DependencyContainer> => {
   const configInstance = getConfig();
-  const handlerTokens = getHandlerTokens(configInstance);
+  const instanceType = getInstanceType(configInstance);
 
   const loggerConfig = configInstance.get('telemetry.logger');
   const logger = await jsLogger({ ...loggerConfig, prettyPrint: loggerConfig.prettyPrint, mixin: getOtelMixin() });
@@ -85,10 +105,7 @@ export const registerExternalValues = async (options?: RegisterOptions): Promise
     { token: SERVICES.TRACER, provider: { useValue: tracer } },
     { token: SERVICES.METRICS, provider: { useValue: metricsRegistry } },
     { token: SERVICES.QUEUE_CLIENT, provider: { useFactory: instancePerContainerCachingFactory(queueClientFactory) } },
-    { token: handlerTokens.NEW, provider: { useClass: IngestionJobHandler } },
-    { token: handlerTokens.UPDATE, provider: { useClass: IngestionJobHandler } },
-    { token: handlerTokens.SWAP, provider: { useClass: IngestionJobHandler } },
-    { token: handlerTokens.EXPORT, provider: { useClass: ExportJobHandler } },
+    ...getHandlerDependencies(instanceType),
     {
       token: SERVICES.S3CONFIG,
       provider: {
@@ -108,7 +125,7 @@ export const registerExternalValues = async (options?: RegisterOptions): Promise
   ];
 
   const registeredContainer = registerDependencies(dependencies, options?.override, options?.useChild);
-  validateRequiredDirectories(registeredContainer);
+  validateRequiredDirectories(registeredContainer, instanceType);
 
   return registeredContainer;
 };

--- a/src/models/handlerFactory.ts
+++ b/src/models/handlerFactory.ts
@@ -1,25 +1,19 @@
 import { container } from 'tsyringe';
 import { BadRequestError } from '@map-colonies/error-types';
 import { IJobHandler, IPermittedJobTypes } from '../common/interfaces';
-import { getHandlerTokens, SERVICES } from '../common/constants';
-import type { ConfigType } from '../common/config';
+import { HANDLER_TOKENS } from '../common/constants';
 import { IngestionJobHandler } from './ingestion/ingestionHandler';
 import { ExportJobHandler } from './export/exportJobHandler';
 
 export function initJobHandler(jobHandlerType: string, permittedTypes: IPermittedJobTypes): IJobHandler {
-  const config = container.resolve<ConfigType>(SERVICES.CONFIG);
-  const handlers = getHandlerTokens(config);
-
   switch (jobHandlerType) {
     case permittedTypes.ingestionNew:
-      return container.resolve<IngestionJobHandler>(handlers.NEW) as IJobHandler;
     case permittedTypes.ingestionUpdate:
-      return container.resolve<IngestionJobHandler>(handlers.UPDATE) as IJobHandler;
     case permittedTypes.ingestionSwapUpdate:
-      return container.resolve<IngestionJobHandler>(handlers.SWAP) as IJobHandler;
+      return container.resolve<IngestionJobHandler>(HANDLER_TOKENS.INGESTION) as IJobHandler;
     /* istanbul ignore next */
     case permittedTypes.exportJob:
-      return container.resolve<ExportJobHandler>(handlers.EXPORT) as IJobHandler;
+      return container.resolve<ExportJobHandler>(HANDLER_TOKENS.EXPORT) as IJobHandler;
   }
   throw new BadRequestError(`${jobHandlerType} job type is invalid`);
 }

--- a/src/models/jobProcessor.ts
+++ b/src/models/jobProcessor.ts
@@ -2,6 +2,7 @@ import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import type { Logger } from '@map-colonies/js-logger';
 import { OperationStatus, TaskHandler as QueueClient, type ITaskResponse } from '@map-colonies/mc-priority-queue';
 import { withSpanAsyncV4, withSpanV4 } from '@map-colonies/telemetry';
+import { InstanceType } from '@map-colonies/raster-shared';
 import type { Tracer } from '@opentelemetry/api';
 import { inject, injectable } from 'tsyringe';
 import { JobTrackerClient } from '../clients/jobTrackerClient';
@@ -29,11 +30,8 @@ export class JobProcessor {
     @inject(TaskMetrics) private readonly taskMetrics: TaskMetrics
   ) {
     this.dequeueIntervalMs = this.config.get('jobManagement.config.dequeueIntervalMs') as unknown as number;
-    const ingestionNew = this.config.get('jobDefinitions.jobs.new.type') as unknown as string;
-    const ingestionUpdate = this.config.get('jobDefinitions.jobs.update.type') as unknown as string;
-    const ingestionSwapUpdate = this.config.get('jobDefinitions.jobs.swapUpdate.type') as unknown as string;
-    const exportJob = this.config.get('jobDefinitions.jobs.export.type') as unknown as string;
-    this.jobTypesToProcess = { ingestionNew, ingestionUpdate, ingestionSwapUpdate, exportJob };
+    const instanceType = this.config.get('instanceType') as InstanceType;
+    this.jobTypesToProcess = this.setUpJobTypesToProcess(instanceType);
     this.configuredTasks = this.config.get('jobDefinitions.tasks') as unknown as ITasksConfig;
     this.taskTypesToProcess = this.setUpTaskTypesToProcess(this.configuredTasks);
   }
@@ -114,10 +112,23 @@ export class JobProcessor {
     }
   }
 
+  private setUpJobTypesToProcess(instanceType: InstanceType): IPermittedJobTypes {
+    if (instanceType === InstanceType.EXPORT) {
+      const exportJob = this.config.get('jobDefinitions.jobs.export.type') as unknown as string;
+      return { exportJob };
+    }
+    const ingestionNew = this.config.get('jobDefinitions.jobs.new.type') as unknown as string;
+    const ingestionUpdate = this.config.get('jobDefinitions.jobs.update.type') as unknown as string;
+    const ingestionSwapUpdate = this.config.get('jobDefinitions.jobs.swapUpdate.type') as unknown as string;
+    return { ingestionNew, ingestionUpdate, ingestionSwapUpdate };
+  }
+
   private setUpTaskTypesToProcess(configTasks: ITasksConfig): string[] {
-    const taskTypes = [];
+    const taskTypes: string[] = [];
     for (const [, taskConfig] of Object.entries(configTasks)) {
-      taskTypes.push(taskConfig.type);
+      if (taskConfig.type) {
+        taskTypes.push(taskConfig.type);
+      }
     }
     return taskTypes;
   }

--- a/tests/integration/fixtures/testFixturesFactory.ts
+++ b/tests/integration/fixtures/testFixturesFactory.ts
@@ -5,14 +5,18 @@ import { IJobResponse, ITaskResponse, OperationStatus } from '@map-colonies/mc-p
 import { ProductType } from '@map-colonies/mc-model-types';
 import { IngestionJobParams, ValidationTaskParameters } from '../../../src/common/interfaces';
 import { configMock, registerDefaultConfig } from '../../unit/mocks/configMock';
-import { getHandlerTokens } from '../../../src/common/constants';
 
 registerDefaultConfig();
 
-/** Job handler type strings as defined in the integration test config. */
-const handlers = getHandlerTokens(configMock);
+/** Ingestion job type strings as defined in the integration test config. */
+const jobTypes = {
+  new: configMock.get('jobDefinitions.jobs.new.type') as unknown as string,
+  update: configMock.get('jobDefinitions.jobs.update.type') as unknown as string,
+  swapUpdate: configMock.get('jobDefinitions.jobs.swapUpdate.type') as unknown as string,
+  export: configMock.get('jobDefinitions.jobs.export.type') as unknown as string,
+};
 
-export { handlers };
+export { jobTypes };
 
 export interface CreateJobOptions {
   jobId?: string;
@@ -38,7 +42,7 @@ export interface CreateTaskOptions {
 
 export function createIngestionJob(options: CreateJobOptions = {}): IJobResponse<IngestionJobParams, unknown> {
   const jobId = options.jobId ?? randomUUID();
-  const type = options.type ?? handlers.NEW;
+  const type = options.type ?? jobTypes.new;
   const resourceId = options.resourceId ?? 'test_product_id';
   const version = options.version ?? '1.0';
   const productType = options.productType ?? ProductType.ORTHOPHOTO;

--- a/tests/integration/mocks/httpMocks.ts
+++ b/tests/integration/mocks/httpMocks.ts
@@ -49,11 +49,11 @@ export class HttpMockHelper {
   }
 
   public static mockJobManagerSearchTasks(jobType: string, taskTypes: string[], task: ITaskResponse<unknown>): void {
-    for (const currentJobType of Object.values(jobTypes)) {
+    for (const jobType of Object.values(jobTypes)) {
       for (const taskType of taskTypes) {
         nock(mockUrls.jobManagerUrl)
-          .post(`/tasks/${currentJobType}/${taskType}/startPending`)
-          .reply(StatusCodes.OK, jobType === currentJobType ? task : undefined);
+          .post(`/tasks/${jobType}/${taskType}/startPending`)
+          .reply(StatusCodes.OK, jobType === jobType ? task : undefined);
       }
     }
   }

--- a/tests/integration/mocks/httpMocks.ts
+++ b/tests/integration/mocks/httpMocks.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 import { IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
 import { PolygonPartsChunkValidationResult } from '@map-colonies/raster-shared';
 import { StatusCodes } from 'http-status-codes';
-import { handlers } from '../fixtures/testFixturesFactory';
+import { jobTypes } from '../fixtures/testFixturesFactory';
 import { configMock } from '../../unit/mocks/configMock';
 
 export interface MockHttpUrls {
@@ -49,11 +49,11 @@ export class HttpMockHelper {
   }
 
   public static mockJobManagerSearchTasks(jobType: string, taskTypes: string[], task: ITaskResponse<unknown>): void {
-    for (const handler of Object.values(handlers)) {
+    for (const currentJobType of Object.values(jobTypes)) {
       for (const taskType of taskTypes) {
         nock(mockUrls.jobManagerUrl)
-          .post(`/tasks/${handler}/${taskType}/startPending`)
-          .reply(StatusCodes.OK, jobType === handler ? task : undefined);
+          .post(`/tasks/${currentJobType}/${taskType}/startPending`)
+          .reply(StatusCodes.OK, jobType === currentJobType ? task : undefined);
       }
     }
   }

--- a/tests/integration/validationTaksFlow/validationTaskFlow.spec.ts
+++ b/tests/integration/validationTaksFlow/validationTaskFlow.spec.ts
@@ -14,7 +14,7 @@ import { PolygonPartsManagerClient } from '../../../src/clients/polygonPartsMana
 import { ShapefileNotFoundError } from '../../../src/common/errors';
 import { JobTrackerClient } from '../../../src/clients/jobTrackerClient';
 import { configMock, registerDefaultConfig, setValue } from '../../unit/mocks/configMock';
-import { createIngestionJob, createTask, handlers } from '../fixtures/testFixturesFactory';
+import { createIngestionJob, createTask, jobTypes } from '../fixtures/testFixturesFactory';
 import { HttpMockHelper } from '../mocks/httpMocks';
 import { CallbackClient } from '../../../src/clients/callbackClient';
 import { getTestContainerConfig, resetContainer } from '../testContainerConfig';
@@ -59,7 +59,7 @@ describe('Validation Task Flow', () => {
   });
 
   describe('Happy Path - Successful Validation', () => {
-    test.each([handlers.NEW, handlers.UPDATE, handlers.SWAP])('should complete validation task successfully for %s handler', async (type) => {
+    test.each([jobTypes.new, jobTypes.update, jobTypes.swapUpdate])('should complete validation task successfully for %s handler', async (type) => {
       const job = createIngestionJob({
         shapefilePath: '/valid/137_parts_valid/ShapeMetadata.shp',
         type,

--- a/tests/integration/validationTaksFlow/validationTaskFlow.spec.ts
+++ b/tests/integration/validationTaksFlow/validationTaskFlow.spec.ts
@@ -49,6 +49,7 @@ describe('Validation Task Flow', () => {
   });
 
   afterEach(() => {
+    // eslint-disable-next-line import-x/no-named-as-default-member
     nock.cleanAll();
     jest.clearAllMocks();
     resetContainer();

--- a/tests/unit/handlers/handlersFactory.spec.ts
+++ b/tests/unit/handlers/handlersFactory.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { BadRequestError } from '@map-colonies/error-types';
-import { getHandlerTokens, SERVICES } from '../../../src/common/constants';
+import { HANDLER_TOKENS, SERVICES } from '../../../src/common/constants';
 import { initJobHandler } from '../../../src/models/handlerFactory';
 import { IngestionJobHandler } from '../../../src/models/ingestion/ingestionHandler';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
@@ -31,11 +31,10 @@ describe('HandlerFactory', () => {
   beforeEach(async () => {
     (fs.accessSync as jest.Mock).mockImplementation(() => undefined);
     registerDefaultConfig();
-    const handlers = getHandlerTokens(configMock);
     await registerExternalValues({
       override: [
         { token: SERVICES.LOGGER, provider: { useValue: loggerMock } },
-        { token: handlers.NEW, provider: { useValue: ingestionJobHandlerInstance() } },
+        { token: HANDLER_TOKENS.INGESTION, provider: { useValue: ingestionJobHandlerInstance() } },
       ],
     });
   });

--- a/tests/unit/jobProcessor/jobProcessor.spec.ts
+++ b/tests/unit/jobProcessor/jobProcessor.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import { JobProcessor } from '../../../src/models/jobProcessor';
-import { configMock, registerDefaultConfig } from '../mocks/configMock';
+import { configMock, registerDefaultConfig, setValue } from '../mocks/configMock';
 import { failTaskRequest, newJobResponseMock, updatedJobRequest } from '../mocks/jobsMocks';
 import { initTaskForIngestionNew, reachedMaxAttemptsTask } from '../mocks/tasksMocks';
 import * as handlerFactory from '../../../src/models/handlerFactory';
@@ -195,6 +195,41 @@ describe('JobProcessor', () => {
         reachedMaxAttemptsTask.reason
       );
       expect(notifyOnFinishedTaskSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('instanceType polling', () => {
+    it('should poll only the ingestion job types when instanceType is ingestion', async () => {
+      setValue('instanceType', 'ingestion');
+      const ingestionJobProcessor = jobProcessorInstance();
+      const dequeueSpy = jest.spyOn(mockQueueClient, 'dequeue').mockResolvedValue(null);
+
+      const resultPromise = ingestionJobProcessor.start({ runOnce: true });
+      ingestionJobProcessor.stop();
+      await resultPromise;
+
+      const dequeuedJobTypes = dequeueSpy.mock.calls.map(([jobType]) => jobType);
+      expect(dequeuedJobTypes).toContain('Ingestion_New');
+      expect(dequeuedJobTypes).toContain('Ingestion_Update');
+      expect(dequeuedJobTypes).toContain('Ingestion_Swap_Update');
+      expect(dequeuedJobTypes).not.toContain('Export');
+    });
+
+    it('should poll only the export job type when instanceType is export', async () => {
+      setValue('instanceType', 'export');
+      const exportJobType = configMock.get('jobDefinitions.jobs.export.type') as unknown as string;
+      const exportJobProcessor = jobProcessorInstance();
+      const dequeueSpy = jest.spyOn(mockQueueClient, 'dequeue').mockResolvedValue(null);
+
+      const resultPromise = exportJobProcessor.start({ runOnce: true });
+      exportJobProcessor.stop();
+      await resultPromise;
+
+      const dequeuedJobTypes = dequeueSpy.mock.calls.map(([jobType]) => jobType);
+      expect(dequeuedJobTypes).toContain(exportJobType);
+      expect(dequeuedJobTypes).not.toContain('Ingestion_New');
+      expect(dequeuedJobTypes).not.toContain('Ingestion_Update');
+      expect(dequeuedJobTypes).not.toContain('Ingestion_Swap_Update');
     });
   });
 });

--- a/tests/unit/mocks/configMock.ts
+++ b/tests/unit/mocks/configMock.ts
@@ -43,6 +43,7 @@ const setConfigValues = (values: Record<string, unknown>): void => {
 
 const registerDefaultConfig = (): void => {
   const configValues = {
+    instanceType: 'ingestion',
     telemetry: {
       logger: {
         level: 'info',


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

## Summary

The worker previously polled all four job types in a single deployment (3 ingestion jobs + Export). This change lets a worker process run as a single **instanceType** — `ingestion` or `export` — so the two domains can be deployed and scaled independently, each carrying only the resources its domain needs.

## Changes

- **Domain selection** — a new `instanceType` config value (`ingestion` | `export`) drives everything:
  - `JobProcessor` polls only the job types of its domain.
  - `containerConfig` validates `instanceType` at startup, registers only that domain's handler, and validates only the directories that domain uses.
  - `handlerFactory` resolves a single `INGESTION`/`EXPORT` handler token (new/update/swap all map to the one ingestion handler).
- **Config** — `instanceType` key + `INSTANCE_TYPE` env mapping (default `ingestion`).
- **Helm** — renders only the relevant domain's env vars, volumes and S3 secret per `instanceType`, with a guard that fails the render fast on a missing/invalid value. Also restores the missing `common.metrics.merged` helper.
- **Deps** — bumps `@map-colonies/raster-shared` to `^8.2.0` for the shared `InstanceType` const/type.
- **Tests** — ingestion/export polling cases; fixtures/mocks updated for the single handler tokens.

## Verification

- `npm test` (tsc + 127 unit + 23 integration) passes; `eslint` clean.
- `helm template` for each instanceType renders the correct domain-only env/volumes; the guard fails fast when `instanceType` is unset or invalid.