### PR TITLE
fix(deps): upgrade @map-colonies/raster-shared to ^8.3.0 (MAPCO-11282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@map-colonies/mc-priority-queue": "^9.1.0",
         "@map-colonies/mc-utils": "^5.1.0",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "^8.2.0",
+        "@map-colonies/raster-shared": "^8.3.0",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/shapefile-reader": "^1.0.1",
@@ -3280,9 +3280,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.2.0.tgz",
-      "integrity": "sha512-ZdNixVp+7Kw2ZWkRAWFhc2HP43yq9t3ogbv9HzHmI1DU1FiheXnEsJ9UMsSgjwWHY+GqgEy0ElFVE5wf6APtQw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0.tgz",
+      "integrity": "sha512-5faR0iBC9Dpxm7Z8fY+3d+5oolHqVk/urXeOq3nHuIEMOvwRT2TrTr9fmt6TK8DaCjyQXBeEU1nijvuPLHmrEw==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@map-colonies/mc-priority-queue": "^9.1.0",
     "@map-colonies/mc-utils": "^5.1.0",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "^8.2.0",
+    "@map-colonies/raster-shared": "^8.3.0",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/shapefile-reader": "^1.0.1",


### PR DESCRIPTION
## Summary
MAPCO-11282 — upgrade `@map-colonies/raster-shared` to the official **v8.3.0** release.

`^8.2.0` → `^8.3.0`

## Tests
Baseline captured on unmodified `origin/master` first, so a pre-existing failure couldn't be mistaken for a regression.

| | Baseline | After bump |
|---|---|---|
| Unit | 127 passed | 127 passed |
| Integration | 23 passed | 23 passed |

`package-lock.json` regenerated — installed version confirmed as `8.3.0`.
